### PR TITLE
Sort versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
-git ls-remote --tags --refs https://codeberg.org/leiningen/leiningen | sed 's;^.*refs/tags/\(.*\)$;\1;' | xargs echo
+
+# see https://asdf-vm.com/plugins/create.html#bin-list-all for why we shouldn't just `sort -V`
+sort_versions() {
+    sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+	LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
+
+git ls-remote --tags --refs https://codeberg.org/leiningen/leiningen | sed 's;^.*refs/tags/\(.*\)$;\1;' | sort_versions | xargs echo


### PR DESCRIPTION
As things stand `latest` resolves to 2.9.9 rather than 2.10.0 - this uses the same sort function used by rbenv and recommended by the asdf docs.

It's not 100% perfect (`2.0.0-preview10` comes after 1 rather than 9), but it's an improvement 😄 